### PR TITLE
Feature/permissions

### DIFF
--- a/src/main/java/net/twasi/core/Main.java
+++ b/src/main/java/net/twasi/core/Main.java
@@ -6,10 +6,17 @@ import net.twasi.core.cli.CommandLineInterface;
 import net.twasi.core.config.Config;
 import net.twasi.core.database.Database;
 import net.twasi.core.database.models.User;
+import net.twasi.core.database.models.permissions.PermissionEntity;
+import net.twasi.core.database.models.permissions.PermissionEntityType;
+import net.twasi.core.database.models.permissions.PermissionGroups;
+import net.twasi.core.database.models.permissions.Permissions;
 import net.twasi.core.logger.TwasiLogger;
 import net.twasi.core.plugin.Plugin;
 import net.twasi.core.services.InstanceManagerService;
 import net.twasi.core.webinterface.WebInterfaceApp;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Main {
 

--- a/src/main/java/net/twasi/core/Main.java
+++ b/src/main/java/net/twasi/core/Main.java
@@ -6,17 +6,10 @@ import net.twasi.core.cli.CommandLineInterface;
 import net.twasi.core.config.Config;
 import net.twasi.core.database.Database;
 import net.twasi.core.database.models.User;
-import net.twasi.core.database.models.permissions.PermissionEntity;
-import net.twasi.core.database.models.permissions.PermissionEntityType;
-import net.twasi.core.database.models.permissions.PermissionGroups;
-import net.twasi.core.database.models.permissions.Permissions;
 import net.twasi.core.logger.TwasiLogger;
 import net.twasi.core.plugin.Plugin;
 import net.twasi.core.services.InstanceManagerService;
 import net.twasi.core.webinterface.WebInterfaceApp;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class Main {
 

--- a/src/main/java/net/twasi/core/database/models/TwitchAccount.java
+++ b/src/main/java/net/twasi/core/database/models/TwitchAccount.java
@@ -1,8 +1,12 @@
 package net.twasi.core.database.models;
 
+import net.twasi.core.database.models.permissions.PermissionGroups;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.annotations.NotSaved;
+
+import java.util.List;
 
 @Entity("twitchAccounts")
 public class TwitchAccount {
@@ -11,6 +15,9 @@ public class TwitchAccount {
     private String userName;
     private AccessToken token;
     private String twitchId;
+
+    @NotSaved
+    private List<PermissionGroups> groups;
 
     public TwitchAccount() {}
 
@@ -54,5 +61,13 @@ public class TwitchAccount {
 
     public void setTwitchId(String twitchId) {
         this.twitchId = twitchId;
+    }
+
+    public List<PermissionGroups> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<PermissionGroups> groups) {
+        this.groups = groups;
     }
 }

--- a/src/main/java/net/twasi/core/database/models/User.java
+++ b/src/main/java/net/twasi/core/database/models/User.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Entity("users")
 public class User {
 
-    private static TwitchAccount defaultAccount = new TwitchAccount(Config.getCatalog().twitch.defaultName, new AccessToken(Config.getCatalog().twitch.defaultToken), Config.getCatalog().twitch.defaultUserId);
+    private static TwitchAccount defaultAccount;
 
     @Id
     private ObjectId id;
@@ -23,7 +23,14 @@ public class User {
     private GlobalConfig config;
     private List<Permissions> permissions;
 
-    public User() {};
+    public User() {
+        if (Config.getCatalog() != null) {
+            defaultAccount = new TwitchAccount(
+                    Config.getCatalog().twitch.defaultName, new AccessToken(Config.getCatalog().twitch.defaultToken),
+                    Config.getCatalog().twitch.defaultUserId
+            );
+        }
+    };
 
     public ObjectId getId() {
         return id;

--- a/src/main/java/net/twasi/core/database/models/User.java
+++ b/src/main/java/net/twasi/core/database/models/User.java
@@ -1,9 +1,12 @@
 package net.twasi.core.database.models;
 
 import net.twasi.core.config.Config;
+import net.twasi.core.database.models.permissions.Permissions;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Id;
+
+import java.util.List;
 
 @Entity("users")
 public class User {
@@ -18,6 +21,7 @@ public class User {
     private String JWTSecret;
 
     private GlobalConfig config;
+    private List<Permissions> permissions;
 
     public User() {};
 
@@ -70,5 +74,21 @@ public class User {
 
     public void setConfig(GlobalConfig config) {
         this.config = config;
+    }
+
+    public static TwitchAccount getDefaultAccount() {
+        return defaultAccount;
+    }
+
+    public static void setDefaultAccount(TwitchAccount defaultAccount) {
+        User.defaultAccount = defaultAccount;
+    }
+
+    public List<Permissions> getPermissions() {
+        return permissions;
+    }
+
+    public void setPermissions(List<Permissions> permissions) {
+        this.permissions = permissions;
     }
 }

--- a/src/main/java/net/twasi/core/database/models/User.java
+++ b/src/main/java/net/twasi/core/database/models/User.java
@@ -91,4 +91,13 @@ public class User {
     public void setPermissions(List<Permissions> permissions) {
         this.permissions = permissions;
     }
+
+    public boolean hasPermission(TwitchAccount account, String permissionKey) {
+        for (Permissions perm : getPermissions()) {
+            if (perm.hasPermission(account, permissionKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/net/twasi/core/database/models/permissions/PermissionEntity.java
+++ b/src/main/java/net/twasi/core/database/models/permissions/PermissionEntity.java
@@ -1,0 +1,48 @@
+package net.twasi.core.database.models.permissions;
+
+import net.twasi.core.database.models.TwitchAccount;
+import org.bson.types.ObjectId;
+import org.mongodb.morphia.annotations.Id;
+
+public class PermissionEntity {
+
+    @Id
+    private ObjectId id;
+
+    private PermissionEntityType type;
+
+    private PermissionGroups group;
+    private TwitchAccount account;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public PermissionEntityType getType() {
+        return type;
+    }
+
+    public void setType(PermissionEntityType type) {
+        this.type = type;
+    }
+
+    public PermissionGroups getGroup() {
+        return group;
+    }
+
+    public void setGroup(PermissionGroups group) {
+        this.group = group;
+    }
+
+    public TwitchAccount getAccount() {
+        return account;
+    }
+
+    public void setAccount(TwitchAccount account) {
+        this.account = account;
+    }
+}

--- a/src/main/java/net/twasi/core/database/models/permissions/PermissionEntityType.java
+++ b/src/main/java/net/twasi/core/database/models/permissions/PermissionEntityType.java
@@ -1,0 +1,11 @@
+package net.twasi.core.database.models.permissions;
+
+public enum PermissionEntityType {
+
+    // A group like viewers, broadcaster or subscribers
+    GROUP,
+
+    // A single person (Twitch Account needed)
+    SINGLE
+
+}

--- a/src/main/java/net/twasi/core/database/models/permissions/PermissionGroups.java
+++ b/src/main/java/net/twasi/core/database/models/permissions/PermissionGroups.java
@@ -1,0 +1,17 @@
+package net.twasi.core.database.models.permissions;
+
+public enum PermissionGroups {
+
+    // Only the broadcaster
+    BROADCASTER,
+
+    // Only moderators (inherits broadcaster)
+    MODERATOR,
+
+    // Subscriber (inherits moderator)
+    SUBSCRIBERS,
+
+    // Viewer (all)
+    VIEWER
+
+}

--- a/src/main/java/net/twasi/core/database/models/permissions/Permissions.java
+++ b/src/main/java/net/twasi/core/database/models/permissions/Permissions.java
@@ -1,0 +1,48 @@
+package net.twasi.core.database.models.permissions;
+
+import org.bson.types.ObjectId;
+import org.mongodb.morphia.annotations.Id;
+
+import java.util.List;
+
+public class Permissions {
+
+    @Id
+    private ObjectId id;
+
+    private List<PermissionEntity> entities;
+    private List<String> keys;
+    private String name;
+
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+
+    public List<PermissionEntity> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(List<PermissionEntity> entities) {
+        this.entities = entities;
+    }
+
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    public void setKeys(List<String> keys) {
+        this.keys = keys;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/net/twasi/core/database/models/permissions/Permissions.java
+++ b/src/main/java/net/twasi/core/database/models/permissions/Permissions.java
@@ -1,5 +1,6 @@
 package net.twasi.core.database.models.permissions;
 
+import net.twasi.core.database.models.TwitchAccount;
 import org.bson.types.ObjectId;
 import org.mongodb.morphia.annotations.Id;
 
@@ -44,5 +45,24 @@ public class Permissions {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public boolean hasPermission(TwitchAccount account, String permissionKey) {
+        if (!getKeys().contains(permissionKey)) {
+            return false;
+        }
+        for (PermissionEntity entity : getEntities()) {
+            if (entity.getType() == PermissionEntityType.SINGLE) {
+                if (entity.getAccount().getTwitchId().equals(account.getTwitchId())) {
+                    return true;
+                }
+            }
+            if (entity.getType() == PermissionEntityType.GROUP) {
+                if (account.getGroups().contains(entity.getGroup())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/net/twasi/core/database/store/UserStore.java
+++ b/src/main/java/net/twasi/core/database/store/UserStore.java
@@ -3,8 +3,13 @@ package net.twasi.core.database.store;
 import net.twasi.core.database.Database;
 import net.twasi.core.database.models.TwitchAccount;
 import net.twasi.core.database.models.User;
+import net.twasi.core.database.models.permissions.PermissionEntity;
+import net.twasi.core.database.models.permissions.PermissionEntityType;
+import net.twasi.core.database.models.permissions.PermissionGroups;
+import net.twasi.core.database.models.permissions.Permissions;
 import net.twasi.core.logger.TwasiLogger;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/net/twasi/core/plugin/PluginConfig.java
+++ b/src/main/java/net/twasi/core/plugin/PluginConfig.java
@@ -12,6 +12,7 @@ public class PluginConfig {
     public boolean messageHandler;
 
     public List<String> commands;
+    public List<String> permissions;
 
     public String getName() {
         return name;
@@ -31,6 +32,10 @@ public class PluginConfig {
 
     public String getMain() {
         return main;
+    }
+
+    public List<String> getPermissions() {
+        return permissions;
     }
 
     public boolean handlesMessages() {

--- a/src/test/java/net/twasi/core/database/PermissionsTest.java
+++ b/src/test/java/net/twasi/core/database/PermissionsTest.java
@@ -87,7 +87,7 @@ public class PermissionsTest {
     }
 
     @Test
-    public void revokesPermissionByGroup() {
+    public void revokesPermission() {
         Boolean hasAddPermission = user.hasPermission(viewer, "commands.add");
         Boolean hasEditPermission = user.hasPermission(viewer, "commands.edit");
         Boolean hasDeletePermission = user.hasPermission(viewer, "commands.delete");

--- a/src/test/java/net/twasi/core/database/PermissionsTest.java
+++ b/src/test/java/net/twasi/core/database/PermissionsTest.java
@@ -1,0 +1,100 @@
+package net.twasi.core.database;
+
+import com.sun.org.apache.xpath.internal.operations.Bool;
+import net.twasi.core.database.models.TwitchAccount;
+import net.twasi.core.database.models.User;
+import net.twasi.core.database.models.permissions.PermissionEntity;
+import net.twasi.core.database.models.permissions.PermissionEntityType;
+import net.twasi.core.database.models.permissions.PermissionGroups;
+import net.twasi.core.database.models.permissions.Permissions;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PermissionsTest {
+
+    // botDeveloper is Viewer and Subscriber. He has TwitchID 1.
+    public TwitchAccount botDeveloper = new TwitchAccount() {{
+        setGroups(new ArrayList<PermissionGroups>() {{
+            add(PermissionGroups.VIEWER);
+            add(PermissionGroups.SUBSCRIBERS);
+        }});
+        setTwitchId("1");
+    }};
+    // moderator is a moderator. He has TwitchID 2.
+    public TwitchAccount moderator = new TwitchAccount() {{
+        setGroups(new ArrayList<PermissionGroups>() {{
+            add(PermissionGroups.VIEWER);
+            add(PermissionGroups.SUBSCRIBERS);
+            add(PermissionGroups.MODERATOR);
+        }});
+        setTwitchId("2");
+    }};
+    // viewer is just a viewer with TwitchID 3.
+    public TwitchAccount viewer = new TwitchAccount() {{
+        setGroups(new ArrayList<PermissionGroups>() {{
+            add(PermissionGroups.VIEWER);
+        }});
+        setTwitchId("3");
+    }};
+
+    public List<Permissions> examplePermissions = new ArrayList<Permissions>() {{
+        add(new Permissions() {{
+            setName("Moderators and Bot Developer");
+            setKeys(new ArrayList<String>() {{
+                add("commands.add");
+                add("commands.edit");
+                add("commands.delete");
+            }});
+            setEntities(new ArrayList<PermissionEntity>() {{
+                add(new PermissionEntity() {{
+                    setGroup(PermissionGroups.MODERATOR);
+                    setType(PermissionEntityType.GROUP);
+                }});
+                add(new PermissionEntity() {{
+                    setAccount(botDeveloper);
+                    setType(PermissionEntityType.SINGLE);
+                }});
+            }});
+        }});
+    }};
+
+    public User user = new User() {{
+        setPermissions(examplePermissions);
+    }};
+
+    @Test
+    public void grantsPermissionByGroup() {
+        Boolean hasAddPermission = user.hasPermission(moderator, "commands.add");
+        Boolean hasEditPermission = user.hasPermission(moderator, "commands.edit");
+        Boolean hasDeletePermission = user.hasPermission(moderator, "commands.delete");
+
+        Assert.assertTrue(hasAddPermission);
+        Assert.assertTrue(hasEditPermission);
+        Assert.assertTrue(hasDeletePermission);
+    }
+
+    @Test
+    public void grantsPermissionByAccount() {
+        Boolean hasAddPermission = user.hasPermission(botDeveloper, "commands.add");
+        Boolean hasEditPermission = user.hasPermission(botDeveloper, "commands.edit");
+        Boolean hasDeletePermission = user.hasPermission(botDeveloper, "commands.delete");
+
+        Assert.assertTrue(hasAddPermission);
+        Assert.assertTrue(hasEditPermission);
+        Assert.assertTrue(hasDeletePermission);
+    }
+
+    @Test
+    public void revokesPermissionByGroup() {
+        Boolean hasAddPermission = user.hasPermission(viewer, "commands.add");
+        Boolean hasEditPermission = user.hasPermission(viewer, "commands.edit");
+        Boolean hasDeletePermission = user.hasPermission(viewer, "commands.delete");
+
+        Assert.assertFalse(hasAddPermission);
+        Assert.assertFalse(hasEditPermission);
+        Assert.assertFalse(hasDeletePermission);
+    }
+}

--- a/src/test/java/net/twasi/core/database/PermissionsTest.java
+++ b/src/test/java/net/twasi/core/database/PermissionsTest.java
@@ -1,6 +1,5 @@
 package net.twasi.core.database;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import net.twasi.core.database.models.TwitchAccount;
 import net.twasi.core.database.models.User;
 import net.twasi.core.database.models.permissions.PermissionEntity;


### PR DESCRIPTION
Added a permission System.

First you create a Group. You can combine predefined Groups (like moderators, viewers, broadcaster etc.) and users by TwitchID. This allows you to create a Group with all Moderators + a bot Developer e.g.